### PR TITLE
Fix file upload error (HTTP Error 400)

### DIFF
--- a/backlog/attachment.py
+++ b/backlog/attachment.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-import requests
 import os.path
+import mimetypes
 
 
 class Attachment(object):
@@ -18,13 +18,12 @@ class Attachment(object):
         if not os.path.exists(filename):
             raise FileNotFoundError(filename)
 
-        with open(filename, "rb") as fp:
-            _uri = "space/attachment"
-            _method = "POST"
-            _files = {
-                os.path.basename(filename): fp
-            }
+        _uri = "space/attachment"
+        _method = "POST"
+        _files = {
+            'file': (os.path.basename(filename), open(filename, 'rb'), mimetypes.guess_type(filename))
+        }
 
-            resp = self.api.invoke_method(_method, _uri, files=_files)
+        resp = self.api.invoke_method(_method, _uri, files=_files)
 
-            return resp.json()
+        return resp.json()


### PR DESCRIPTION
This PR fixes an HTTP Error 400 when using upload function such as `api.attachment.upload("test.txt")`.

detailed error:

```
backlog.base.BacklogError: Http response 400: {"errors":[{"message":"Internal error","code":1,"moreInfo":""}]}
```
